### PR TITLE
Add basic Metrics service for listing/updating metrics

### DIFF
--- a/librato/client.go
+++ b/librato/client.go
@@ -45,6 +45,8 @@ type Client struct {
 
 	// Services used to manipulate API entities.
 	Spaces *SpacesService
+
+	Metrics *MetricsService
 }
 
 // NewClient returns a new Librato API client bound to the public Librato API.
@@ -74,6 +76,7 @@ func NewClientWithBaseURL(baseURL *url.URL, email, token string) *Client {
 	}
 
 	c.Spaces = &SpacesService{client: c}
+	c.Metrics = &MetricsService{client: c}
 
 	return c
 }

--- a/librato/metrics.go
+++ b/librato/metrics.go
@@ -1,0 +1,87 @@
+package librato
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type MetricsService struct {
+	client *Client
+}
+
+type Metric struct {
+	Name        *string           `json:"name"`
+	Period      *uint             `json:"period,omitempty"`
+	DisplayName *string           `json:"display_name,omitempty"`
+	Attributes  *MetricAttributes `json:"attributes,omitempty"`
+}
+
+type MetricAttributes struct {
+	Color *string `json:"color"`
+	// These are interface{} because sometimes the Librato API
+	// returns strings, and sometimes it returns integers
+	DisplayMax        interface{} `json:"display_max"`
+	DisplayMin        interface{} `json:"display_min"`
+	DisplayUnitsShort string      `json:"display_units_short"`
+	DisplayStacked    bool        `json:"display_stacked"`
+	DisplayTransform  string      `json:"display_transform"`
+}
+
+type ListMetricsOptions struct {
+	*PaginationMeta
+	Name string `url:"name,omitempty"`
+}
+
+// Advance to the specified page in result set, while retaining
+// the filtering options.
+func (l *ListMetricsOptions) AdvancePage(next *PaginationMeta) ListMetricsOptions {
+	return ListMetricsOptions{
+		PaginationMeta: next,
+		Name:           l.Name,
+	}
+}
+
+type ListMetricsResponse struct {
+	ThisPage *PaginationResponseMeta
+	NextPage *PaginationMeta
+}
+
+func (m *MetricsService) List(opts *ListMetricsOptions) ([]Metric, *ListMetricsResponse, error) {
+	u, err := urlWithOptions("metrics", opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := m.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var metricsResponse struct {
+		Query   PaginationResponseMeta
+		Metrics []Metric
+	}
+
+	_, err = m.client.Do(req, &metricsResponse)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return metricsResponse.Metrics,
+		&ListMetricsResponse{
+			ThisPage: &metricsResponse.Query,
+			NextPage: metricsResponse.Query.nextPage(opts.PaginationMeta),
+		},
+		nil
+}
+
+func (m *MetricsService) Update(metric *Metric) (*http.Response, error) {
+	u := fmt.Sprintf("metrics/%s", *metric.Name)
+
+	req, err := m.client.NewRequest("PUT", u, metric)
+	if err != nil {
+		return nil, err
+	}
+
+	return m.client.Do(req, nil)
+}

--- a/librato/pagination.go
+++ b/librato/pagination.go
@@ -1,0 +1,66 @@
+package librato
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// Pagination metadata from Librato API responses
+type PaginationResponseMeta struct {
+	Offset uint `json:"offset"`
+	Length uint `json:"length"`
+	Total  uint `json:"total"`
+	Found  uint `json:"found"`
+}
+
+// Calculate the pagination metadata for the next page of the result set.
+// Takes the metadata used to request the current page so that it can use the
+// same sort/orderby options
+func (p *PaginationResponseMeta) nextPage(originalQuery *PaginationMeta) (next *PaginationMeta) {
+	nextOffset := p.Offset + p.Length
+
+	if nextOffset >= p.Found {
+		return nil
+	}
+
+	next = &PaginationMeta{}
+	next.Offset = nextOffset
+	next.Length = p.Length
+
+	if originalQuery != nil {
+		next.OrderBy = originalQuery.OrderBy
+		next.Sort = originalQuery.Sort
+	}
+
+	return next
+}
+
+// Metadata that the librato API requires for pagination
+// http://dev.librato.com/v1/pagination
+type PaginationMeta struct {
+	Offset  uint   `url:"offset,omitempty"`
+	Length  uint   `url:"length,omitempty"`
+	OrderBy string `url:"orderby,omitempty"`
+	Sort    string `url:"sort,omitempty"`
+}
+
+// Custom Encoder for the query string encoder library.
+// The encoder allows other structs to embed PaginationMeta, and have it
+// appear in the top-level query string fields without nesting.
+func (m *PaginationMeta) EncodeValues(name string, values *url.Values) error {
+	if m == nil {
+		return nil
+	}
+
+	values.Set("offset", fmt.Sprintf("%d", m.Offset))
+	values.Set("length", fmt.Sprintf("%d", m.Length))
+
+	if m.OrderBy != "" {
+		values.Set("orderby", m.OrderBy)
+	}
+	if m.Sort != "" {
+		values.Set("sort", m.Sort)
+	}
+
+	return nil
+}

--- a/librato/pagination_test.go
+++ b/librato/pagination_test.go
@@ -1,0 +1,86 @@
+package librato
+
+import (
+	"testing"
+
+	"github.com/google/go-querystring/query"
+)
+
+func TestEmbeddedPaginationIsNotNestedInQueryStringParameters(t *testing.T) {
+	var options = struct{ *PaginationMeta }{
+		PaginationMeta: &PaginationMeta{
+			Offset:  10,
+			Length:  20,
+			OrderBy: "name",
+			Sort:    "desc",
+		},
+	}
+
+	expected := "length=20&offset=10&orderby=name&sort=desc"
+
+	qs, err := query.Values(options)
+
+	if err != nil {
+		t.Fatalf("unexpected error when encoding values: %#v", err)
+	}
+
+	encoded := qs.Encode()
+	if encoded != expected {
+		t.Errorf("struct values were not extracted correctly: %#v", encoded)
+	}
+
+}
+
+func TestEncodingOptionsStructWithoutPaginationDoesNotResultInPanic(t *testing.T) {
+	var options = struct{ *PaginationMeta }{}
+
+	qs, err := query.Values(options)
+
+	if err != nil {
+		t.Fatalf("unexpected error when encoding values: %#v", err)
+	}
+
+	encoded := qs.Encode()
+
+	if encoded != "" {
+		t.Errorf("expected encoded query string to be empty, got: %#v", encoded)
+	}
+}
+
+func TestNextPageReturnsNilWhenOnLastPage(t *testing.T) {
+	current := PaginationResponseMeta{
+		Offset: 0,
+		Length: 100,
+		Total:  200,
+		Found:  100,
+	}
+
+	got := current.nextPage(nil)
+
+	if got != nil {
+		t.Errorf("expected pagination meta for next page to be nil when at end of results, got: %#v", got)
+	}
+}
+func TestCalculatingCursorPositionForNextPage(t *testing.T) {
+	current := PaginationResponseMeta{
+		Offset: 0,
+		Length: 100,
+		Total:  200,
+		Found:  200,
+	}
+
+	expected := PaginationMeta{
+		Offset: 100,
+		Length: 100,
+	}
+
+	got := current.nextPage(nil)
+
+	if got == nil {
+		t.Fatalf("did not expect meta for next page to be nil: %#v", got)
+	}
+
+	if *got != expected {
+		t.Errorf("did not get expected pagination meta: %#v", *got)
+	}
+}


### PR DESCRIPTION
Sorry for not creating an issue first - I was messing around with the library before I saw the guidelines. 

This is a bit rough around the edges as I just implemented the bits I needed to test something out. I intend to add the other functions, but I'd appreciate any comments/criticisms you have at the moment.

The current implementation allows you to list metrics and update an individual one. Here's an example:

```go
package main

import (
        "fmt"
        "regexp"

        "github.com/henrikhodne/go-librato/librato"
)

var (
        PERCENTILE_PATTERN = regexp.MustCompile(`\.p(?:\d{2,3}(?:\.\d+)?)\z`)
)

func main() {
        client := librato.NewClient("email", "api_key")

        opts := librato.ListMetricsOptions{Name: "aws"}

        for {
                metrics, resp, err := client.Metrics.List(&opts)

                if err != nil {
                        fmt.Println(err)
                }

                for _, m := range metrics {
                        fmt.Println(*m.Name)
                        if PERCENTILE_PATTERN.MatchString(*m.Name) {
                                //fmt.Printf("name=%s display_min=%d\n", *m.Name, m.Attributes.DisplayMin)
                        }
                }

                if resp.NextPage == nil {
                        break
                }

                opts = opts.AdvancePage(resp.NextPage)
        }
}
```