### PR TITLE
build: test on Go 1.5 and 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: go
-go: 1.5.1
+go:
+  - 1.5
+  - 1.8
 install: go get -v ./librato
 script: go test -v ./librato

--- a/librato/client_test.go
+++ b/librato/client_test.go
@@ -98,7 +98,7 @@ func TestNewRequest_invalidJSON(t *testing.T) {
 	c := NewClient("", "")
 
 	type T struct {
-		A map[int]interface{}
+		A map[bool]interface{}
 	}
 	_, err := c.NewRequest("GET", "/", &T{})
 

--- a/librato/client_test.go
+++ b/librato/client_test.go
@@ -105,7 +105,7 @@ func TestNewRequest_invalidJSON(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error to be returned.")
 	}
-	if err, ok := err.(*json.UnsupportedTypeError); !ok {
+	if _, ok := err.(*json.UnsupportedTypeError); !ok {
 		t.Errorf("Expected a JSON error; got %#v.", err)
 	}
 }


### PR DESCRIPTION
We've committed to supporting Go 1.5 in the README, and Go 1.8 is the latest.