### PR TITLE
Remove outdated metric attribute, make API methods consistent

### DIFF
--- a/librato/alerts.go
+++ b/librato/alerts.go
@@ -83,10 +83,10 @@ func (a *AlertsService) Create(alert *Alert) (*Alert, *http.Response, error) {
 	return al, resp, err
 }
 
-// Edit an alert.
+// Update an alert.
 //
 // Librato API docs: https://www.librato.com/docs/api/?shell#update-alert
-func (a *AlertsService) Edit(alertID uint, alert *Alert) (*http.Response, error) {
+func (a *AlertsService) Update(alertID uint, alert *Alert) (*http.Response, error) {
 	u := fmt.Sprintf("alerts/%d", alertID)
 	req, err := a.client.NewRequest("PUT", u, alert)
 	if err != nil {

--- a/librato/metrics.go
+++ b/librato/metrics.go
@@ -32,7 +32,6 @@ type MetricAttributes struct {
 	DisplayUnitsLong  string      `json:"display_units_long"`
 	DisplayUnitsShort string      `json:"display_units_short"`
 	DisplayStacked    bool        `json:"display_stacked"`
-	DisplayTransform  string      `json:"display_transform"`
 	CreatedByUA       string      `json:"created_by_ua,omitempty"`
 	GapDetection      bool        `json:"gap_detection,omitempty"`
 	Aggregate         bool        `json:"aggregate,omitempty"`
@@ -136,10 +135,10 @@ type GaugeMeasurement struct {
 	SumSquares *float64 `json:"sum_squares,omitempty"`
 }
 
-// Submit metrics
+// Create metrics
 //
 // Librato API docs: https://www.librato.com/docs/api/#create-a-measurement
-func (m *MetricsService) Submit(measurements *MeasurementSubmission) (*http.Response, error) {
+func (m *MetricsService) Create(measurements *MeasurementSubmission) (*http.Response, error) {
 	req, err := m.client.NewRequest("POST", "/metrics", measurements)
 	if err != nil {
 		return nil, err
@@ -148,10 +147,10 @@ func (m *MetricsService) Submit(measurements *MeasurementSubmission) (*http.Resp
 	return m.client.Do(req, nil)
 }
 
-// Edit a metric.
+// Update a metric.
 //
 // Librato API docs: https://www.librato.com/docs/api/#update-a-metric-by-name
-func (m *MetricsService) Edit(metric *Metric) (*http.Response, error) {
+func (m *MetricsService) Update(metric *Metric) (*http.Response, error) {
 	u := fmt.Sprintf("metrics/%s", *metric.Name)
 
 	req, err := m.client.NewRequest("PUT", u, metric)

--- a/librato/services.go
+++ b/librato/services.go
@@ -63,10 +63,10 @@ func (s *ServicesService) Create(service *Service) (*Service, *http.Response, er
 	return sv, resp, err
 }
 
-// Edit a service.
+// Update a service.
 //
 // Librato API docs: https://www.librato.com/docs/api/#update-a-service
-func (s *ServicesService) Edit(serviceID uint, service *Service) (*http.Response, error) {
+func (s *ServicesService) Update(serviceID uint, service *Service) (*http.Response, error) {
 	u := fmt.Sprintf("services/%d", serviceID)
 	req, err := s.client.NewRequest("PUT", u, service)
 	if err != nil {

--- a/librato/spaces.go
+++ b/librato/spaces.go
@@ -96,10 +96,10 @@ func (s *SpacesService) Create(space *Space) (*Space, *http.Response, error) {
 	return sp, resp, err
 }
 
-// Edit a space.
+// Update a space.
 //
 // Librato API docs: http://dev.librato.com/v1/put/spaces/:id
-func (s *SpacesService) Edit(spaceID uint, space *Space) (*http.Response, error) {
+func (s *SpacesService) Update(spaceID uint, space *Space) (*http.Response, error) {
 	u := fmt.Sprintf("spaces/%d", spaceID)
 	req, err := s.client.NewRequest("PUT", u, space)
 	if err != nil {


### PR DESCRIPTION
Remove deprecated metric attribute "DisplayTransform" as the API doesn't appear to support it anymore.

Update several method names for consistency.