### PR TITLE
Add support for 'use_last_value' field on SpaceChart

### DIFF
--- a/librato/spaces_charts.go
+++ b/librato/spaces_charts.go
@@ -13,6 +13,7 @@ type SpaceChart struct {
 	Min          *float64           `json:"min,omitempty"`
 	Max          *float64           `json:"max,omitempty"`
 	Label        *string            `json:"label,omitempty"`
+	UseLastValue *bool              `json:"use_last_value,omitempty"`
 	RelatedSpace *uint              `json:"related_space,omitempty"`
 	Streams      []SpaceChartStream `json:"streams,omitempty"`
 }


### PR DESCRIPTION
This field controls whether the last value is shown:

![image](https://user-images.githubusercontent.com/1046019/29898532-0622e6f2-8d9b-11e7-843c-6b3401cd9eb2.png)

Or if it is summarized according to its summary function:

![image](https://user-images.githubusercontent.com/1046019/29898555-23d75cf0-8d9b-11e7-9e36-4df9d9882fc1.png)


You can see this field in the API like so:

```bash
$ curl -s \
  -u $LIBRATO_USERNAME:$LIBRATO_TOKEN \
  -X GET \
  'https://metrics-api.librato.com/v1/spaces/496540/charts/4771270' | jq .
```

```json
{
  "id": 4771270,
  "name": "HTTP Status Codes",
  "type": "bignumber",
  "streams": [
    {
      "id": 30967547,
      "metric": "router.status.4xx",
      "type": "gauge",
      "source": "%",
      "group_function": "sum",
      "summary_function": "sum"
    }
  ],
  "thresholds": [],
  "use_last_value": false,
  "format": null,
  "enable_format": false
}
```