### PR TITLE
metric attributes: make them all optional

### DIFF
--- a/librato/metrics.go
+++ b/librato/metrics.go
@@ -29,12 +29,12 @@ type MetricAttributes struct {
 	// returns strings, and sometimes it returns integers
 	DisplayMax        interface{} `json:"display_max"`
 	DisplayMin        interface{} `json:"display_min"`
-	DisplayUnitsLong  string      `json:"display_units_long"`
-	DisplayUnitsShort string      `json:"display_units_short"`
-	DisplayStacked    bool        `json:"display_stacked"`
-	CreatedByUA       string      `json:"created_by_ua,omitempty"`
-	GapDetection      bool        `json:"gap_detection,omitempty"`
-	Aggregate         bool        `json:"aggregate,omitempty"`
+	DisplayUnitsLong  *string     `json:"display_units_long"`
+	DisplayUnitsShort *string     `json:"display_units_short"`
+	DisplayStacked    *bool       `json:"display_stacked"`
+	CreatedByUA       *string     `json:"created_by_ua,omitempty"`
+	GapDetection      *bool       `json:"gap_detection,omitempty"`
+	Aggregate         *bool       `json:"aggregate,omitempty"`
 }
 
 // ListMetricsOptions are used to coordinate paging of metrics.


### PR DESCRIPTION
## Context

Given that the librato API typically leaves these out in metric fetch responses, it's easier to determine what was set or not set by making this nullable.

This supports some work with the librato terraform provider and being able to be idempotent when it comes to re-updating things.